### PR TITLE
setup-go: support labeled docker images better

### DIFF
--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       # NOTE: uses only the first version found in the Dockerfile... maybe warn if multiple?
       run: |
-        GO_VERSION=$(grep -E '^FROM golang:' ${{ inputs.dockerfile }} | cut -d ':' -f 2 | cut -d ' ' -f 1 | head -n 1)
+        GO_VERSION=$(grep -E '^FROM golang:' ${{ inputs.dockerfile }} | sed -E 's/^FROM golang:([0-9]+\.[0-9]+)(-.*)?.*$/\1/' | head -n 1)
         echo "extracted_version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Setup Go


### PR DESCRIPTION
For: #3
