### PR TITLE
fix: caching, find all go.sum in repo dynamically and pass to setup-go

### DIFF
--- a/actions/setup-go/action.yml
+++ b/actions/setup-go/action.yml
@@ -1,4 +1,4 @@
-name: 'MKMBA setup-go'
+name: 'MKMBA setup-go (test)'
 description: 'Sets up Go with MKMBA defaults and Dockerfile version extraction'
 
 inputs:
@@ -21,6 +21,14 @@ runs:
         GO_VERSION=$(grep -E '^FROM golang:' ${{ inputs.dockerfile }} | sed -E 's/^FROM golang:([0-9]+\.[0-9]+)(-.*)?.*$/\1/' | head -n 1)
         echo "extracted_version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
+    - name: find go.sum
+      id: go-sum
+      run: |
+        files=$(find "${{ github.workspace }}" -name go.sum)
+        echo "paths<<EOF" >> $GITHUB_OUTPUT
+        echo "$files" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
@@ -28,9 +36,7 @@ runs:
         go-version: ${{ inputs.go-version || steps.extract-version.outputs.extracted_version || '1.23' }}
         check-latest: true
         cache: true
-        cache-dependency-path: :-
-          "${{ github.workspace }}/**/go.sum"
-          "go.sum"
+        cache-dependency-path: ${{ steps.go-sum.outputs.paths }}
 
     - name: Set GOTOOLCHAIN
       shell: bash


### PR DESCRIPTION
Theoretically can use globbing for this, but having trouble making that
work reliably.
