### PR TITLE
fix: reduce ecr/ecs shared workflows assumptions

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,6 +6,12 @@ permissions:
 on:
   workflow_call:
     inputs:
+      role-to-assume:
+        required: true
+        type: string
+      region:
+        required: true
+        type: string
       registries:
         required: false
       repo-name:
@@ -20,6 +26,10 @@ on:
       build-args:
         required: false
         type: string
+      platforms:
+        required: false
+        type: string
+        default: linux/amd64
 
 jobs:
   build-and-push:
@@ -28,8 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ vars.project_number }}:role/${{ vars.role_name }}
-          aws-region: us-east-2
+          role-to-assume: ${{ inputs.role-to-assume }}
+          aws-region: ${{ inputs.region }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,7 +48,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
         with:
-          reigstries: ${{ inputs.registries }}
+          registries: ${{ inputs.registries }}
 
       - name: Build, tag, and push docker image to Amazon ECR
         uses: docker/build-push-action@v6
@@ -47,7 +57,7 @@ jobs:
           target: ${{ inputs.target }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           build-args: ${{ inputs.build-args }}
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.repo-name }}:${{ github.sha }}

--- a/.github/workflows/deploy-to-ecs.yml
+++ b/.github/workflows/deploy-to-ecs.yml
@@ -7,12 +7,22 @@ permissions:
 on:
   workflow_call:
     inputs:
+      role-to-assume:
+        required: true
+        type: string
       region:
+        required: true
+        type: string      
+      registry:
         required: true
         type: string
       repo-name:
-          required: true
-          type: string
+        required: true
+        type: string
+      wait-for-replication:
+        required: false
+        type: boolean
+        default: false
       cluster-name:
         required: true
         type: string
@@ -43,15 +53,16 @@ jobs:
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::${{ vars.project_number }}:role/${{ vars.role_name}}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
 
     - name: wait for ECR replication
       uses: siketyan/wait-for-ecr-replication-action@v1.1.4
-      if: ${{ inputs.region != 'us-east-2' }}
+      if: ${{ inputs.wait-for-replication }}
       with:
         image_tag: ${{ github.sha }}
-        repository_uri: ${{ vars.project_number }}.dkr.ecr.us-east-2.amazonaws.com/${{ inputs.repo-name }}
+        repository_name: ${{ inputs.repo-name }}
+        registry_id: ${{ inputs.registry }}
 
     - name: fetch current task definition
       run: |
@@ -61,7 +72,7 @@ jobs:
       id: render
       run: |
         cat template.json | \
-        jq 'setpath(["containerDefinitions", 0, "image"]; "${{ vars.project_number }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ inputs.repo-name }}:${{ github.sha }}")' | \
+        jq 'setpath(["containerDefinitions", 0, "image"]; "${{ inputs.registry }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ inputs.repo-name }}:${{ github.sha }}")' | \
         jq 'setpath(["family"]; "${{ inputs.task-family }}") | delpaths([["taskDefinitionArn"],["registeredAt"],["registeredBy"]])' \
         > task-definition.json
         cat task-definition.json
@@ -80,6 +91,7 @@ jobs:
       run: |
         aws ssm put-parameter --name /${{ inputs.parameter-prefix != '' && inputs.parameter-prefix || inputs.task-family }}/image_tag --type String --value ${{ github.sha }} --overwrite
 
+    # TODO: make this work with cross-account registries (role assumption!)
     - name: add deployment tag to image in ECR as a docker tag
       if: ${{ inputs.deployed-to-env != '' }}
       run: |


### PR DESCRIPTION
- take role/region for login as arguments
- don't assume us-east-2 is replication source
- support cross-account registries via arguments

Deployment tagging cross-account is not yet functional as it requires
another layer of role assumption AFAICT (from deployment account into
registry account role!) TODO!
