### PR TITLE
jul17 1554

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+.agent-manager-launch-*.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
 # Normal rules.
 * @mattbnz
 
+# Allow doc commits without CODEOWNER approval (e.g. bot approvals!)
+# but still subject to all other approvals.
+/docs/**
+
 # Always last - Protect GitHub config explicitly
 /.github/ @mattbnz


### PR DESCRIPTION
- **allow agents to commit docs without human approval**
- **gitignore agent-manager devcontainer launch configs**
