### PR TITLE
feat(build-and-push): add optional runs-on input for native arm64 builds

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: linux/amd64
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+        description: "Runner label for the build job. Set to ubuntu-24.04-arm to build linux/arm64 natively rather than under QEMU emulation."
       cache-mounts:
         required: false
         type: string
@@ -49,7 +54,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -87,9 +92,13 @@ jobs:
           # github.sha rolls the key every run so the restored cache is always re-saved
           # with new entries (actions/cache never updates an existing key); restore-keys
           # falls back to the most recent prior cache for this image.
-          key: ${{ runner.os }}-cache-mounts-${{ inputs.repo-name }}-${{ github.sha }}
+          # runner.arch keeps X64 and ARM64 caches apart - runner.os is `Linux` for both,
+          # and these are raw directory tarballs with no internal arch tagging, so an
+          # amd64 cache restored into an arm64 build can yield unusable artefacts (e.g.
+          # compiled native gem extensions).
+          key: ${{ runner.os }}-${{ runner.arch }}-cache-mounts-${{ inputs.repo-name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cache-mounts-${{ inputs.repo-name }}-
+            ${{ runner.os }}-${{ runner.arch }}-cache-mounts-${{ inputs.repo-name }}-
 
       - name: Inject cache mounts into BuildKit
         if: ${{ inputs.cache-mounts != '' }}


### PR DESCRIPTION
The reusable workflow hardcoded runs-on: ubuntu-latest forcing callers
to cross-build rather than use native runners when required.

Add a runs-on input (default ubuntu-latest) so callers targeting arm64
can select a native runner. Default callers are unchanged.

Also scope the cache-mounts key by runner.arch. runner.os is Linux on
both architectures, so the restore-keys prefix previously let an amd64
cache-mount tarball restore into an arm64 build. These are raw
directory tarballs with no internal arch tagging -- benign for Go,
which tags its own build cache, but wrong for a bundle cache holding
compiled native gem extensions. Existing cache-mounts callers take a
one-off cold build as the new prefix populates.

The type=gha layer cache scope is left shared across architectures:
BuildKit keys those entries by layer digest, which includes the
per-platform base image manifest, so an arm64 build misses amd64
entries rather than restoring them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
