### PR TITLE
fix: repair diff-hash dedupe in shared review-agent workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,10 +40,11 @@ otherwise enumerate.
 
 ## Conventions
 
-- **Bot login.** `bot-name` takes the `[bot]`-suffixed user login
-  (e.g. `mkmba-review-agent[bot]`). The workflow strips the suffix when
-  matching against GraphQL `author.login` values, which omit `[bot]` for
-  App actors.
+- **Bot login.** The review bot is the org-wide `mkmba-review-agent` App,
+  hardcoded in the workflow. GraphQL `author.login` omits the `[bot]`
+  suffix for App actors, so the workflow matches reviews and comments
+  against the bare slug (`BOT_SLUG`) and passes the `[bot]`-suffixed login
+  to the review action as `bot_name`.
 - **Human vs agent.** The "is this a human reviewer?" check (auto mode
   only) excludes any reviewer whose login ends in `-agent`. Org-wide
   convention: every automated review-posting bot's slug ends in `-agent`.
@@ -134,11 +135,18 @@ The text is appended verbatim to the end of the prompt. Combine with
 3. **A prior review exists with a different diff hash** → re-review, but
    in "focus on what's changed since the previous review" mode.
 4. **No prior review** → first-pass review.
+5. **The comment fetch itself fails** (e.g. a GitHub API blip) → the job
+   fails with an `::error::` annotation, and no review is posted.
 
 Every review summary comment ends with a `diff-hash:<sha256>` marker that
 the dedupe logic reads on subsequent runs. Requested-mode re-reviews also
 emit this marker, so a subsequent auto-mode run on the same diff will
 correctly skip.
+
+Case 5 is deliberately fail-closed: if we cannot read the prior comments we
+cannot tell case 2 from case 4, and treating that as "no prior review" is
+what silently disabled the dedupe entirely for the workflow's first year.
+Re-run the job to recover from a transient failure.
 
 In `requested` mode none of the above applies — the workflow always
 proceeds to the review step.

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -71,8 +71,8 @@ name: Review Agent (shared)
 #   - All other review-agent bots in the org have logins ending in "-agent"
 #     (so the human-reviewer detection can exclude them with a single test).
 #   - The review bot's GraphQL author.login is the App slug without "[bot]"
-#     (GraphQL renders Bot actor logins this way) - we derive the slug from
-#     the [bot]-suffixed name passed in `bot-name`.
+#     (GraphQL renders Bot actor logins this way) - so matching is done
+#     against the bare slug in BOT_SLUG.
 
 on:
   workflow_call:
@@ -166,8 +166,16 @@ jobs:
           fi
 
           # mode=auto: dedupe by diff hash against prior bot comments.
-          BOT_COMMENTS=$(gh pr view "$PR_NUMBER" --json comments \
-            --jq --arg bot "$BOT_SLUG" '.comments[] | select(.author.login == $bot) | .body' || true)
+          # gh's --jq takes a filter string only - it is not jq and rejects jq
+          # flags like --arg - so the filter reads BOT_SLUG from the environment.
+          # Keep the fetch out of a pipeline: the default shell is `bash -e`
+          # without pipefail, so `gh ... | jq ...` would swallow a gh failure and
+          # silently degrade into "no prior reviews" - the defect fixed here.
+          if ! BOT_COMMENTS=$(gh pr view "$PR_NUMBER" --json comments \
+              --jq '.comments[] | select(.author.login == env.BOT_SLUG) | .body'); then
+            echo "::error::Could not fetch comments for PR #$PR_NUMBER - unable to tell whether diff-hash:$DIFF_HASH has already been reviewed"
+            exit 1
+          fi
           EXACT_MATCH=$(echo "$BOT_COMMENTS" | grep "diff-hash:$DIFF_HASH" | tail -1 || true)
           PREVIOUS_HASH=$(echo "$BOT_COMMENTS" | grep -oP 'diff-hash:\K[a-f0-9]{64}' | tail -1 || true)
 


### PR DESCRIPTION
The dedupe that is meant to stop the review agent re-reviewing an
unchanged diff has never run. The call that fetches prior bot comments
passed jq's --arg to gh's --jq, but gh's --jq is a plain filter string
and takes no jq flags: gh bound --arg as the filter and treated the
remaining tokens as positional arguments, exiting with "accepts at most
1 arg(s), received 4". A trailing `|| true` swallowed that, leaving
BOT_COMMENTS empty, so every run fell through to the "first review"
branch. Present since the workflow was introduced, so the dedupe has
been a no-op org-wide for its whole life; the diff-hash marker was
written faithfully and never read.

The filter now reads BOT_SLUG via jq's `env`, which keeps the whole
thing in a single gh call and needs no jq-only flags. The fetch is
deliberately not piped into jq: the default `run:` shell is `bash -e`
without pipefail, so a gh failure inside a pipeline would be swallowed
again. Dropping `|| true` and guarding the call makes a fetch failure
loud rather than degrading it into an unconditional review - converting
a hard error into "no prior reviews found" is precisely what hid this
for so long. The `|| true` on the two grep pipelines stays; those
legitimately exit 1 when there is no match.

The README gains the new fail-closed case, and the workflow header and
README Conventions bullet no longer describe the slug as being derived
from the `bot-name` input, which was removed in 35c0cc7.

For: FZ-2363
