### PR TITLE
fix: drop --depth=1 from origin fetch so diverged branches diff correctly

### DIFF
--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Compute diff hash
         id: diff
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          git fetch origin ${{ github.event.pull_request.base.ref }}
           DIFF_HASH=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | sha256sum | cut -d' ' -f1)
           echo "diff_hash=$DIFF_HASH" >> $GITHUB_OUTPUT
           echo "::notice::Computed diff-hash:$DIFF_HASH"


### PR DESCRIPTION
Noticed by Claude while implementing FZ-2347, with --depth=1 the
checkout is shallow and the diff fails, providing empty input into the
hash!
